### PR TITLE
🐛 FIX: Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ potential_dict = {
     'N  N  Ga': '1.0 0.001632 0.000 65.20700 2.82100 -0.518000 1.0 0.0 0.00000 0.00000 2.90 0.20 0.00000 0.00000',
     'Ga N  Ga': '1.0 0.007874 1.846 1.918000 0.75000 -0.301300 1.0 0.0 0.00000 0.00000 2.87 0.15 0.00000 0.00000'}
 potential = DataFactory("lammps.potential")(
-    structure=structure, type=pair_style, data=potential_dict
+    type=pair_style, data=potential_dict
 )
 potential.attributes
 ```

--- a/examples/launch_lammps_force_gan.py
+++ b/examples/launch_lammps_force_gan.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     # setup nodes
     inputs.structure = structure
     inputs.potential = EmpiricalPotential(
-        type=potential['pair_style'], data=potential['data']
+        type=potential["pair_style"], data=potential["data"]
     )
 
     # run calculation

--- a/examples/launch_lammps_force_gan.py
+++ b/examples/launch_lammps_force_gan.py
@@ -81,9 +81,8 @@ if __name__ == "__main__":
 
     # setup nodes
     inputs.structure = structure
-    # inputs.potential = Dict(dict=potential)
     inputs.potential = EmpiricalPotential(
-        structure=structure, type="tersoff", data=tersoff_gan
+        type=potential['pair_style'], data=potential['data']
     )
 
     # run calculation

--- a/examples/launch_lammps_md_si.py
+++ b/examples/launch_lammps_md_si.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     # setup nodes
     inputs.structure = structure
     inputs.potential = EmpiricalPotential(
-        type=potential['pair_style'], data=potential['data']
+        type=potential["pair_style"], data=potential["data"]
     )
 
     inputs.parameters = Dict(dict=parameters_md)

--- a/examples/launch_lammps_md_si.py
+++ b/examples/launch_lammps_md_si.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     # setup nodes
     inputs.structure = structure
     inputs.potential = EmpiricalPotential(
-        structure=structure, type="tersoff", data=tersoff_si
+        type=potential['pair_style'], data=potential['data']
     )
 
     inputs.parameters = Dict(dict=parameters_md)

--- a/examples/launch_lammps_optimization_fe.py
+++ b/examples/launch_lammps_optimization_fe.py
@@ -87,9 +87,8 @@ if __name__ == "__main__":
 
     # setup nodes
     inputs.structure = structure
-    # inputs.potential = Dict(dict=potential)
     inputs.potential = EmpiricalPotential(
-        structure=structure, type="eam", data=eam_data
+        type=potential['pair_style'], data=potential['data']
     )
 
     print(inputs.potential.get_potential_file())

--- a/examples/launch_lammps_optimization_fe.py
+++ b/examples/launch_lammps_optimization_fe.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     # setup nodes
     inputs.structure = structure
     inputs.potential = EmpiricalPotential(
-        type=potential['pair_style'], data=potential['data']
+        type=potential["pair_style"], data=potential["data"]
     )
 
     print(inputs.potential.get_potential_file())

--- a/examples/launch_lammps_optimization_gan.py
+++ b/examples/launch_lammps_optimization_gan.py
@@ -101,9 +101,8 @@ if __name__ == "__main__":
 
     # setup nodes
     inputs.structure = structure
-    # inputs.potential = Dict(dict=potential)
     inputs.potential = EmpiricalPotential(
-        structure=structure, type="tersoff", data=tersoff_gan
+        type=potential['pair_style'], data=potential['data']
     )
 
     inputs.parameters = Dict(dict=parameters_opt)

--- a/examples/launch_lammps_optimization_gan.py
+++ b/examples/launch_lammps_optimization_gan.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     # setup nodes
     inputs.structure = structure
     inputs.potential = EmpiricalPotential(
-        type=potential['pair_style'], data=potential['data']
+        type=potential["pair_style"], data=potential["data"]
     )
 
     inputs.parameters = Dict(dict=parameters_opt)

--- a/examples/launch_lammps_optimization_lj.py
+++ b/examples/launch_lammps_optimization_lj.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # setup nodes
     inputs.structure = structure
     inputs.potential = EmpiricalPotential(
-        type=potential['pair_style'], data=potential['data']
+        type=potential["pair_style"], data=potential["data"]
     )
 
     inputs.parameters = Dict(dict=parameters_opt)

--- a/examples/launch_lammps_optimization_lj.py
+++ b/examples/launch_lammps_optimization_lj.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # setup nodes
     inputs.structure = structure
     inputs.potential = EmpiricalPotential(
-        structure=structure, type="lennard_jones", data={"1  1": "0.01029   3.4    2.5"}
+        type=potential['pair_style'], data=potential['data']
     )
 
     inputs.parameters = Dict(dict=parameters_opt)


### PR DESCRIPTION
Removed the passing of `structure` from the examples and the `README.md`, and made used of the `potential` dictionaries to pass the data to the `EmpiricalPotential` instances. 

Addresses #18