### PR TITLE
Adds custom dump rate and repeat rate. Reduce excessive output

### DIFF
--- a/aiida_lammps/calculations/lammps/optimize.py
+++ b/aiida_lammps/calculations/lammps/optimize.py
@@ -103,9 +103,12 @@ class OptimizeCalculation(BaseLammpsCalculation):
         else:
             dump_variables = "element x y z  fx fy fz c_stpa[1] c_stpa[2] c_stpa[3] c_stpa[4] c_stpa[5] c_stpa[6]"
             dump_format = "%4s " + " ".join(["%16.10f"] * 12)
-
-        lammps_input_file += "dump            aiida all custom 1 {0} {1}\n".format(
-            trajectory_filename, dump_variables
+        
+        
+        dump_rate = parameter_data["minimize"].get("dump_rate", 1_000_000)
+        
+        lammps_input_file += "dump            aiida all custom {0} {1} {2}\n".format(
+            dump_rate, trajectory_filename, dump_variables
         )
 
         # TODO find exact version when changes were made

--- a/aiida_lammps/validation/schemas/md-multi.schema.json
+++ b/aiida_lammps/validation/schemas/md-multi.schema.json
@@ -455,6 +455,12 @@
               "minimum": 1,
               "default": 1
             },
+            "repeat_rate": {
+              "description": "How often to repeat",
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
             "ave_variables": {
               "description": "system level variables to output, per dump_rate, to system array, that will be averaged in accordance with average_rate",
               "type": "array",

--- a/aiida_lammps/validation/schemas/optimize.schema.json
+++ b/aiida_lammps/validation/schemas/optimize.schema.json
@@ -98,6 +98,12 @@
             "cg",
             "sd"
           ]
+        },
+        "dump_rate": {
+          "description": "Dump rate for minimization trajectory output. Defaults to 1M to prevent unnecessarily large files being created.",
+          "type": "integer",
+          "minimum": 1,
+          "default": 1000000
         }
       }
     },


### PR DESCRIPTION
This allows for the repeat rate for system average computes and the dump rate of optimisation trajectories to be specified.

I also set the default dump rate for optimizations to only output every 1M frames (i.e. to only output the first and last frame unless it is taking a ridiculously large time to converge). In the majority of cases, people aren't concerned with _how_ it converged, and with tight convergence critera the corresponding output can be huge.