### PR TITLE
`BaseLammpsCalculation`: Add the `script` input

### DIFF
--- a/aiida_lammps/calculations/lammps/base.py
+++ b/aiida_lammps/calculations/lammps/base.py
@@ -43,21 +43,27 @@ class BaseLammpsCalculation(CalcJob):
     def define(cls, spec):
         super().define(spec)
         spec.input(
+            "script",
+            valid_type=orm.SinglefileData,
+            required=False,
+            help="Complete input script to use. If specified, `structure`, `potential` and `parameters` are ignored.",
+        )
+        spec.input(
             "structure",
             valid_type=orm.StructureData,
-            required=True,
+            required=False,
             help="Structure used in the ``LAMMPS`` calculation",
         )
         spec.input(
             "potential",
             valid_type=LammpsPotentialData,
-            required=True,
+            required=False,
             help="Potential used in the ``LAMMPS`` calculation",
         )
         spec.input(
             "parameters",
             valid_type=orm.Dict,
-            required=True,
+            required=False,
             help="Parameters that control the ``LAMMPS`` calculation",
         )
         spec.input(
@@ -102,6 +108,7 @@ class BaseLammpsCalculation(CalcJob):
             default=cls._DEFAULT_RESTART_FILENAME,
         )
         spec.inputs["metadata"]["options"]["parser_name"].default = cls._DEFAULT_PARSER
+        spec.inputs.validator = cls.validate_inputs
 
         spec.output(
             "results",
@@ -178,28 +185,22 @@ class BaseLammpsCalculation(CalcJob):
             message="error parsing the final variable file has failed.",
         )
 
+    @classmethod
+    def validate_inputs(cls, value, ctx):
+        """Validate the top-level inputs namespace."""
+        if "script" not in value and any(
+            key not in value for key in ("structure", "potential", "parameters")
+        ):
+            return (
+                "Unless `script` is specified the inputs `structure`, `potential` and "
+                "`parameters` have to be specified."
+            )
+
     def prepare_for_submission(self, folder):
         """
         Create the input files from the input nodes passed to this instance of the `CalcJob`.
         """
         # pylint: disable=too-many-locals
-
-        # Generate the content of the structure file based on the input
-        # structure
-        structure_filecontent, _ = generate_lammps_structure(
-            self.inputs.structure,
-            self.inputs.potential.atom_style,
-        )
-
-        # Get the name of the structure file and write it to the remote folder
-        _structure_filename = self.inputs.metadata.options.structure_filename
-
-        with folder.open(_structure_filename, "w") as handle:
-            handle.write(structure_filecontent)
-
-        # Get the parameters dictionary so that they can be used for creating
-        # the input file
-        _parameters = self.inputs.parameters.get_dict()
 
         # Get the name of the trajectory file
         _trajectory_filename = self.inputs.metadata.options.trajectory_filename
@@ -225,27 +226,47 @@ class BaseLammpsCalculation(CalcJob):
         else:
             _read_restart_filename = None
 
-        # Write the input file content. This function will also check the
-        # sanity of the passed paremters when comparing it to a schema
-        input_filecontent = generate_input_file(
-            potential=self.inputs.potential,
-            structure=self.inputs.structure,
-            parameters=_parameters,
-            restart_filename=_restart_filename,
-            trajectory_filename=_trajectory_filename,
-            variables_filename=_variables_filename,
-            read_restart_filename=_read_restart_filename,
-        )
+        if "script" in self.inputs:
+            input_filecontent = self.inputs.script.get_content()
+        else:
+            # Get the parameters dictionary so that they can be used for creating
+            # the input file
+            _parameters = self.inputs.parameters.get_dict()
+
+            # Generate the content of the structure file based on the input
+            # structure
+            structure_filecontent, _ = generate_lammps_structure(
+                self.inputs.structure,
+                self.inputs.potential.atom_style,
+            )
+
+            # Get the name of the structure file and write it to the remote folder
+            _structure_filename = self.inputs.metadata.options.structure_filename
+
+            with folder.open(_structure_filename, "w") as handle:
+                handle.write(structure_filecontent)
+
+            # Write the potential to the remote folder
+            with folder.open(self._DEFAULT_POTENTIAL_FILENAME, "w") as handle:
+                handle.write(self.inputs.potential.get_content())
+
+            # Write the input file content. This function will also check the
+            # sanity of the passed paremters when comparing it to a schema
+            input_filecontent = generate_input_file(
+                potential=self.inputs.potential,
+                structure=self.inputs.structure,
+                parameters=_parameters,
+                restart_filename=_restart_filename,
+                trajectory_filename=_trajectory_filename,
+                variables_filename=_variables_filename,
+                read_restart_filename=_read_restart_filename,
+            )
 
         # Get the name of the input file, and write it to the remote folder
         _input_filename = self.inputs.metadata.options.input_filename
 
         with folder.open(_input_filename, "w") as handle:
             handle.write(input_filecontent)
-
-        # Write the potential to the remote folder
-        with folder.open(self._DEFAULT_POTENTIAL_FILENAME, "w") as handle:
-            handle.write(self.inputs.potential.get_content())
 
         codeinfo = datastructures.CodeInfo()
         # Command line variables to ensure that the input file from LAMMPS can


### PR DESCRIPTION
Fixes #55 

This allows a user to pass a complete input script that should be used as-is. The `structure`, `potential` and `parameters` inputs are completely optional in this case. This gives ultimate flexibility to a user to run whatever they want in exchange for queryability.