### PR TITLE
Remove setting `CalcInfo.uuid` from `CalcJob` plugins

### DIFF
--- a/aiida_lammps/calculations/lammps/__init__.py
+++ b/aiida_lammps/calculations/lammps/__init__.py
@@ -294,7 +294,6 @@ class BaseLammpsCalculation(CalcJob):
         codeinfo.stdout_name = self._stdout_name
 
         calcinfo = CalcInfo()
-        calcinfo.uuid = self.uuid
         calcinfo.retrieve_list = retrieve_list
         calcinfo.retrieve_temporary_list = retrieve_temporary_list
         calcinfo.codes_info = [codeinfo]

--- a/aiida_lammps/calculations/lammps/base.py
+++ b/aiida_lammps/calculations/lammps/base.py
@@ -279,7 +279,6 @@ class BaseLammpsCalculation(CalcJob):
 
         # Generate the datastructure for the calculation information
         calcinfo = datastructures.CalcInfo()
-        calcinfo.uuid = str(self.uuid)
         # Set the files that must be retrieved
         calcinfo.retrieve_list = []
         calcinfo.retrieve_list.append(_output_filename)


### PR DESCRIPTION
This is done by the `CalcJob` base class.