### PR TITLE
Adding the codecov token explicitly to try to get rid of the failures when running the tests at the codecov stage.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,6 +89,7 @@ jobs:
         if: matrix.python-version == 3.8
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           name: pytests-lammps
           flags: pytests
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         if: matrix.python-version == 3.8
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           name: pytests-lammps
           flags: pytests
           fail_ci_if_error: true


### PR DESCRIPTION
Adding the codecov token explicitly to avoid failures when uploading codecov coverage. Addresses #62 