### PR TITLE
Docs: Update Python version on RTD to 3.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
+
 python:
-  version: "3.8"
   install:
-      - method: pip
-        path: .
-        extra_requirements:
-          - docs
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 sphinx:
   builder: html


### PR DESCRIPTION
A recent release of `urllib3` was breaking the build, see: https://github.com/urllib3/urllib3/issues/2168
The problem does not apply to more recent versions of Python.