### PR TITLE
:ok_hand: Adding validators to the extra tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: "3.8"
       - name: Make sure virtualevn>20 is installed, which will yield newer pip and possibility to pin pip version.
-        run: pip install virtualenv>20
+        run: pip install "virtualenv>20"
       - name: Install Tox
         run: pip install tox
       - name: Run pre-commit in Tox
@@ -78,7 +78,7 @@ jobs:
         run: conda install -c conda-forge jpeg
 
       - name: Make sure virtualevn>20 is installed, which will yield newer pip and possibility to pin pip version.
-        run: pip install virtualenv>20
+        run: pip install "virtualenv>20"
       - name: Install Tox
         run: pip install tox
 

--- a/aiida_lammps/data/potential.py
+++ b/aiida_lammps/data/potential.py
@@ -23,7 +23,7 @@ import io
 import json
 import os
 import pathlib
-import typing
+from typing import BinaryIO, List, Optional, Union
 
 from aiida import orm, plugins
 from aiida.common.constants import elements
@@ -82,14 +82,14 @@ class LammpsPotentialData(orm.SinglefileData):
     @classmethod
     def get_or_create(
         cls,
-        source: typing.Union[str, pathlib.Path, typing.BinaryIO],
+        source: Union[str, pathlib.Path, BinaryIO],
         filename: str = None,
         pair_style: str = None,
         species: list = None,
         atom_style: str = None,
         units: str = None,
-        developer: typing.Union[str, typing.List[str]] = None,
-        publication_year: typing.Union[str, int, datetime.datetime] = None,
+        developer: Union[str, List[str]] = None,
+        publication_year: Union[str, int, datetime.datetime] = None,
         title: str = None,
         extra_tags: dict = None,
     ):
@@ -102,7 +102,7 @@ class LammpsPotentialData(orm.SinglefileData):
         :param source: the source potential content, either a binary stream,
             or a ``str`` or ``Path`` to the path of the file on disk,
             which can be relative or absolute.
-        :type source: typing.Union[str, pathlib.Path, typing,BinaryIO]
+        :type source: Union[str, pathlib.Path, BinaryIO]
         :param filename: optional explicit filename to give to the file stored in the repository.
         :type filename: str
         :param pair_style: Type of potential according to LAMMPS
@@ -114,9 +114,9 @@ class LammpsPotentialData(orm.SinglefileData):
         :param units: Default units to be used with this potential.
         :type units:  str
         :param developer: Name or list of names of the developer(s) of the potential.
-        :type developers: typing.Union[str, typing.List[str]]
+        :type developers: Union[str, List[str]]
         :param publication_year: Year of publication of the potential.
-        :type publication_year: typing.Union[str, int, datetime.datetime]
+        :type publication_year: Union[str, int, datetime.datetime]
         :para title: title given to the potential.
         :type title: str
         :param extra_tags: Dictionary with extra information to tag the
@@ -180,9 +180,7 @@ class LammpsPotentialData(orm.SinglefileData):
         )
 
     @classmethod
-    def prepare_source(
-        cls, source: typing.Union[str, pathlib.Path, typing.BinaryIO]
-    ) -> typing.BinaryIO:
+    def prepare_source(cls, source: Union[str, pathlib.Path, BinaryIO]) -> BinaryIO:
         """Validate the ``source`` representing a file on disk or a byte stream.
 
         .. note:: if the ``source`` is a valid file on disk, its content is
@@ -328,12 +326,12 @@ class LammpsPotentialData(orm.SinglefileData):
             raise TypeError(f'The title "{title}" is not of type str')
         self.base.attributes.set("title", title)
 
-    def validate_developer(self, developer: typing.Union[str, typing.List[str]]):
+    def validate_developer(self, developer: Union[str, List[str]]):
         """
         Validate the developer of the potential
 
         :param developer: name of the developer(s) of the potential
-        :type developer: typing.Union[str, typing.List[str]]
+        :type developer: Union[str, List[str]]
         :raises ValueError: raise if the developer is a falsy value
         :raises TypeError: raise if the developer is not a str or List[str]
         """
@@ -351,13 +349,13 @@ class LammpsPotentialData(orm.SinglefileData):
         self.base.attributes.set("developer", developer)
 
     def validate_publication_year(
-        self, publication_year: typing.Union[str, int, datetime.datetime]
+        self, publication_year: Union[str, int, datetime.datetime]
     ):
         """
         Validate the publication year of the potential
 
         :param publication_year: publication year of the potential
-        :type publication_year: typing.Union[str,int, datetime.datetime]
+        :type publication_year: Union[str,int, datetime.datetime]
         :raises ValueError: raise if the publication year is a falsy value
         :raises TypeError: raise if the publication year is not a str, int or datetime.datetime
         """
@@ -399,14 +397,14 @@ class LammpsPotentialData(orm.SinglefileData):
 
     def set_file(
         self,
-        source: typing.Union[str, pathlib.Path, typing.BinaryIO],
+        source: Union[str, pathlib.Path, BinaryIO],
         filename: str = None,
         pair_style: str = None,
         species: list = None,
         atom_style: str = None,
         units: str = None,
-        developer: typing.Union[str, typing.List[str]] = None,
-        publication_year: typing.Union[str, int, datetime.datetime] = None,
+        developer: Union[str, List[str]] = None,
+        publication_year: Union[str, int, datetime.datetime] = None,
         title: str = None,
         extra_tags: dict = None,
         **kwargs,
@@ -429,7 +427,7 @@ class LammpsPotentialData(orm.SinglefileData):
         :param source: the source lammps potential content, either a binary
             stream, or a ``str`` or ``Path`` to the path of the file on disk,
             which can be relative or absolute.
-        :type source: typing.Union[str, pathlib.Path, typing.BinaryIO]
+        :type source: Union[str, pathlib.Path, BinaryIO]
         :param filename: optional explicit filename to give to the file stored in the repository.
         :type filename: str
         :param pair_style: Type of potential according to LAMMPS
@@ -441,9 +439,9 @@ class LammpsPotentialData(orm.SinglefileData):
         :param units: Default units to be used with this potential.
         :type units:  str
         :param developer: Name or list of names of the developer(s) of the potential.
-        :type developers: typing.Union[str, typing.List[str]]
+        :type developers: Union[str, List[str]]
         :param publication_year: Year of publication of the potential.
-        :type publication_year: typing.Union[str, int, datetime.datetime]
+        :type publication_year: Union[str, int, datetime.datetime]
         :para title: title given to the potential.
         :type title: str
         :param extra_tags: Dictionary with extra information to tag the
@@ -559,7 +557,7 @@ class LammpsPotentialData(orm.SinglefileData):
         return self.base.attributes.get("content_origin")
 
     @property
-    def content_other_locations(self) -> typing.Union[str, list]:
+    def content_other_locations(self) -> Union[str, list]:
         """
         Return other locations where the potential can be found.
 
@@ -567,7 +565,7 @@ class LammpsPotentialData(orm.SinglefileData):
         to other location(s) where the content is available.
 
         :return: other locations where the potential can be found.
-        :rtype: typing.Union[str, list]
+        :rtype: Union[str, list]
         """
         return self.base.attributes.get("content_other_locations")
 
@@ -601,7 +599,7 @@ class LammpsPotentialData(orm.SinglefileData):
         return self.base.attributes.get("description")
 
     @property
-    def developer(self) -> typing.Union[str, list]:
+    def developer(self) -> Union[str, list]:
         """
         Return the developer information of this potential.
 
@@ -612,7 +610,7 @@ class LammpsPotentialData(orm.SinglefileData):
         of an interatomic model or a specific parameter set for it.
 
         :return: developer information of this potential
-        :rtype: typing.Union[str, list]
+        :rtype: Union[str, list]
         """
         return self.base.attributes.get("developer")
 
@@ -631,31 +629,31 @@ class LammpsPotentialData(orm.SinglefileData):
         return self.base.attributes.get("disclaimer")
 
     @property
-    def properties(self) -> typing.Union[str, list]:
+    def properties(self) -> Union[str, list]:
         """
         Return the properties for which this potential was devised.
 
         As based in the KIM schema. A list of properties reported by a KIM Item.
 
         :return: properties fow which this potential was devised.
-        :rtype: typing.Union[str, list]
+        :rtype: Union[str, list]
         """
         return self.base.attributes.get("properties")
 
     @property
-    def publication_year(self) -> typing.Union[str, datetime.datetime, int]:
+    def publication_year(self) -> Union[str, datetime.datetime, int]:
         """
         Return the year of publication of this potential.
 
         As based in the KIM schema. Year this item was published on openkim.org.
 
         :return: year of publication of this potential
-        :rtype: typing.Union[str, datetime.datetime, int]
+        :rtype: Union[str, datetime.datetime, int]
         """
         return self.base.attributes.get("publication_year")
 
     @property
-    def source_citations(self) -> typing.Union[str, list]:
+    def source_citations(self) -> Union[str, list]:
         """
         Return the citation where the potential was originally published.
 
@@ -663,7 +661,7 @@ class LammpsPotentialData(orm.SinglefileData):
         corresponding to primary published work(s) describing the KIM Item.
 
         :return: the citation where the potential was originally published.
-        :rtype: typing.Union[str, list]
+        :rtype: Union[str, list]
         """
         return self.base.attributes.get("source_citations")
 
@@ -682,7 +680,7 @@ class LammpsPotentialData(orm.SinglefileData):
         return self.base.attributes.get("title")
 
     @property
-    def md5(self) -> typing.Optional[int]:
+    def md5(self) -> Optional[int]:
         """Return the md5.
         :return: the md5 of the stored file.
         """

--- a/aiida_lammps/fixtures/data.py
+++ b/aiida_lammps/fixtures/data.py
@@ -59,10 +59,10 @@ def get_potential_fe_eam() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
-        "publication_year": 2018,
-        "developer": ["Ronald E. Miller"],
-        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
+            "publication_year": 2018,
+            "developer": ["Ronald E. Miller"],
+            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
             "data_method": "unknown",

--- a/aiida_lammps/fixtures/data.py
+++ b/aiida_lammps/fixtures/data.py
@@ -1,3 +1,4 @@
+"""Pytest fixtures dealing with data structures used in the tests"""
 import os
 
 from aiida import orm
@@ -58,6 +59,9 @@ def get_potential_fe_eam() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
+        "publication_year": 2018,
+        "developer": ["Ronald E. Miller"],
+        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
@@ -71,13 +75,11 @@ def get_potential_fe_eam() -> LammpsPotentialData:
             The file header includes a note from the NIST contributor:
             \"The potential was taken from v9_4_bcc (in C:\\SIMULATION.MD\\Fe\\Results\\ab_initio+Interstitials)\"
             """,
-            "developer": ["Ronald E. Miller"],
             "disclaimer": """According to the developer Giovanni Bonny
             (as reported by the NIST IPRP), this potential was not stiffened and cannot
             be used in its present form for collision cascades.
             """,
             "properties": None,
-            "publication_year": 2018,
             "source_citations": [
                 {
                     "abstract": None,
@@ -94,7 +96,6 @@ def get_potential_fe_eam() -> LammpsPotentialData:
                     "year": "{2003}",
                 }
             ],
-            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         },
     }
 

--- a/aiida_lammps/parsers/inputfile.py
+++ b/aiida_lammps/parsers/inputfile.py
@@ -17,11 +17,11 @@ import re
 from typing import Union
 
 from aiida import orm
-import jsonschema
 import numpy as np
 
 from aiida_lammps.data.potential import LammpsPotentialData
 from aiida_lammps.parsers.utils import flatten, generate_header
+from aiida_lammps.validation.utils import validate_against_schema
 
 
 def generate_input_file(
@@ -187,16 +187,14 @@ def validate_input_parameters(parameters: dict = None):
     :param parameters: dictionary with the input parameters, defaults to None
     :type parameters: dict, optional
     """
+
     _file = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "..",
         "validation/schemas/lammps_schema.json",
     )
 
-    with open(_file) as handler:
-        schema = json.load(handler)
-
-    jsonschema.validate(schema=schema, instance=parameters)
+    validate_against_schema(data=parameters, filename=_file)
 
 
 def write_control_block(parameters_control: dict) -> str:

--- a/aiida_lammps/validation/__init__.py
+++ b/aiida_lammps/validation/__init__.py
@@ -1,6 +1,2 @@
 """Package for validating JSON objects against schemas."""
-from aiida_lammps.validation.utils import (  # noqa: F401
-    load_schema,
-    load_validator,
-    validate_against_schema,
-)
+from aiida_lammps.validation.utils import validate_against_schema  # noqa: F401

--- a/aiida_lammps/validation/utils.py
+++ b/aiida_lammps/validation/utils.py
@@ -2,82 +2,21 @@
 """Utility functions for validating JSON objects against schemas."""
 import json
 import os
+from typing import Union
 
-import importlib_resources
 import jsonschema
 
-from aiida_lammps.validation import schemas
 
-
-def load_schema(name):
-    """Read and return a JSON schema.
-
-    If the name is an absolute path, it will be used as is, otherwise
-    it will be loaded as resource from the internal json schema module.
-
-    :param name: str
-
-    :return: dict
-    """
-    if os.path.isabs(name):
-        with open(name) as jfile:
-            schema = json.load(jfile)
-    else:
-        schema = json.loads(
-            importlib_resources.files(schemas).joinpath(name).read_text()
-        )
-
-    return schema
-
-
-def load_validator(schema):
-    """Create a validator for a schema.
-
-    :param schema: str or dict schema or path to schema
-
-    :return: jsonschema.IValidator the validator to use
-    """
-    if isinstance(schema, str):
-        schema = load_schema(schema)
-
-    validator_cls = jsonschema.validators.validator_for(schema)
-    validator_cls.check_schema(schema)
-
-    # by default, only validates lists
-    def is_array(checker, instance):  # pylint: disable=unused-argument
-        return isinstance(instance, (tuple, list))
-
-    type_checker = validator_cls.TYPE_CHECKER.redefine("array", is_array)
-    validator_cls = jsonschema.validators.extend(
-        validator_cls, type_checker=type_checker
-    )
-
-    validator = validator_cls(schema=schema)
-    return validator
-
-
-def validate_against_schema(data, schema):
+def validate_against_schema(data: dict, filename: Union[str, os.PathLike]):
     """Validate json-type data against a schema.
 
-    :param data: dict
-    :param schema: dict or str schema, name of schema resource, or absolute path to a schema
-
-    :raises jsonschema.exceptions.SchemaError: if the schema is invalid
-    :raises jsonschema.exceptions.ValidationError: if the instance is invalid
-
-    :return: return True if validated
+    :param data: dictionary with the parameters to be validated
+    :type data: dict
+    :param filename: name or path of the schema to validate against
+    :type filename: Union[str, os.PathLike]
     """
-    validator = load_validator(schema)
-    # validator.validate(data)
-    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
-    if errors:
-        raise jsonschema.ValidationError(
-            "\n".join(
-                [
-                    f'- {error.message} [key path: "{"/".join([str(p) for p in error.path])}"]'
-                    for error in errors
-                ]
-            )
-        )
 
-    return True
+    with open(filename, encoding="utf8") as handler:
+        schema = json.load(handler)
+
+    jsonschema.validate(schema=schema, instance=data)

--- a/examples/launch_lammps_base_md.py
+++ b/examples/launch_lammps_base_md.py
@@ -59,10 +59,10 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
-        "publication_year": 2018,
-        "developer": ["Ronald E. Miller"],
-        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
+            "publication_year": 2018,
+            "developer": ["Ronald E. Miller"],
+            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
             "data_method": "unknown",

--- a/examples/launch_lammps_base_md.py
+++ b/examples/launch_lammps_base_md.py
@@ -59,6 +59,9 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
+        "publication_year": 2018,
+        "developer": ["Ronald E. Miller"],
+        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
@@ -72,13 +75,11 @@ def generate_potential() -> LammpsPotentialData:
             The file header includes a note from the NIST contributor:
             \"The potential was taken from v9_4_bcc (in C:\\SIMULATION.MD\\Fe\\Results\\ab_initio+Interstitials)\"
             """,
-            "developer": ["Ronald E. Miller"],
             "disclaimer": """According to the developer Giovanni Bonny
             (as reported by the NIST IPRP), this potential was not stiffened and cannot
             be used in its present form for collision cascades.
             """,
             "properties": None,
-            "publication_year": 2018,
             "source_citations": [
                 {
                     "abstract": None,
@@ -95,7 +96,6 @@ def generate_potential() -> LammpsPotentialData:
                     "year": "{2003}",
                 }
             ],
-            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         },
     }
 

--- a/examples/launch_lammps_base_minimize.py
+++ b/examples/launch_lammps_base_minimize.py
@@ -60,6 +60,9 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
+        "publication_year": 2018,
+        "developer": ["Ronald E. Miller"],
+        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
@@ -73,13 +76,11 @@ def generate_potential() -> LammpsPotentialData:
             The file header includes a note from the NIST contributor:
             \"The potential was taken from v9_4_bcc (in C:\\SIMULATION.MD\\Fe\\Results\\ab_initio+Interstitials)\"
             """,
-            "developer": ["Ronald E. Miller"],
             "disclaimer": """According to the developer Giovanni Bonny
             (as reported by the NIST IPRP), this potential was not stiffened and cannot
             be used in its present form for collision cascades.
             """,
             "properties": None,
-            "publication_year": 2018,
             "source_citations": [
                 {
                     "abstract": None,
@@ -96,7 +97,6 @@ def generate_potential() -> LammpsPotentialData:
                     "year": "{2003}",
                 }
             ],
-            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         },
     }
 

--- a/examples/launch_lammps_base_minimize.py
+++ b/examples/launch_lammps_base_minimize.py
@@ -60,10 +60,10 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
-        "publication_year": 2018,
-        "developer": ["Ronald E. Miller"],
-        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
+            "publication_year": 2018,
+            "developer": ["Ronald E. Miller"],
+            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
             "data_method": "unknown",

--- a/examples/launch_lammps_base_restart_file.py
+++ b/examples/launch_lammps_base_restart_file.py
@@ -59,10 +59,10 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
-        "publication_year": 2018,
-        "developer": ["Ronald E. Miller"],
-        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
+            "publication_year": 2018,
+            "developer": ["Ronald E. Miller"],
+            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
             "data_method": "unknown",

--- a/examples/launch_lammps_base_restart_file.py
+++ b/examples/launch_lammps_base_restart_file.py
@@ -59,6 +59,9 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
+        "publication_year": 2018,
+        "developer": ["Ronald E. Miller"],
+        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
@@ -72,13 +75,11 @@ def generate_potential() -> LammpsPotentialData:
             The file header includes a note from the NIST contributor:
             \"The potential was taken from v9_4_bcc (in C:\\SIMULATION.MD\\Fe\\Results\\ab_initio+Interstitials)\"
             """,
-            "developer": ["Ronald E. Miller"],
             "disclaimer": """According to the developer Giovanni Bonny
             (as reported by the NIST IPRP), this potential was not stiffened and cannot
             be used in its present form for collision cascades.
             """,
             "properties": None,
-            "publication_year": 2018,
             "source_citations": [
                 {
                     "abstract": None,
@@ -95,7 +96,6 @@ def generate_potential() -> LammpsPotentialData:
                     "year": "{2003}",
                 }
             ],
-            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         },
     }
 

--- a/examples/launch_lammps_base_restart_folder.py
+++ b/examples/launch_lammps_base_restart_folder.py
@@ -59,10 +59,10 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
-        "publication_year": 2018,
-        "developer": ["Ronald E. Miller"],
-        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
+            "publication_year": 2018,
+            "developer": ["Ronald E. Miller"],
+            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
             "data_method": "unknown",

--- a/examples/launch_lammps_base_restart_folder.py
+++ b/examples/launch_lammps_base_restart_folder.py
@@ -59,6 +59,9 @@ def generate_potential() -> LammpsPotentialData:
         "atom_style": "atomic",
         "pair_style": "eam/fs",
         "units": "metal",
+        "publication_year": 2018,
+        "developer": ["Ronald E. Miller"],
+        "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         "extra_tags": {
             "content_origin": "NIST IPRP: https: // www.ctcms.nist.gov/potentials/Fe.html",
             "content_other_locations": None,
@@ -72,13 +75,11 @@ def generate_potential() -> LammpsPotentialData:
             The file header includes a note from the NIST contributor:
             \"The potential was taken from v9_4_bcc (in C:\\SIMULATION.MD\\Fe\\Results\\ab_initio+Interstitials)\"
             """,
-            "developer": ["Ronald E. Miller"],
             "disclaimer": """According to the developer Giovanni Bonny
             (as reported by the NIST IPRP), this potential was not stiffened and cannot
             be used in its present form for collision cascades.
             """,
             "properties": None,
-            "publication_year": 2018,
             "source_citations": [
                 {
                     "abstract": None,
@@ -95,7 +96,6 @@ def generate_potential() -> LammpsPotentialData:
                     "year": "{2003}",
                 }
             ],
-            "title": "EAM potential (LAMMPS cubic hermite tabulation) for Fe developed by Mendelev et al. (2003) v000",
         },
     }
 

--- a/examples/launch_lammps_base_script.py
+++ b/examples/launch_lammps_base_script.py
@@ -9,11 +9,9 @@ import io
 import textwrap
 
 from aiida import orm
+from aiida.common import AttributeDict
 from aiida.engine import run_get_node
 from aiida.plugins import CalculationFactory
-import numpy as np
-
-from aiida_lammps.data.potential import LammpsPotentialData
 
 
 def main(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "aiida-lammps"
 dynamic = ["version", "description"]
-authors = [{name = "Chris Sewell", email = "chrisj_sewell@hotmail.com"}, {name = "Jonathon Chico", email = "jonathan.chico@sandvik.com"}]
+authors = [{name = "Chris Sewell", email = "chrisj_sewell@hotmail.com"}, {name = "Jonathan Chico", email = "jonathan.chico@sandvik.com"}]
 readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = [

--- a/tests/input_files/parameters/FeW_MO_737567242631_000.eam.alloy.yaml
+++ b/tests/input_files/parameters/FeW_MO_737567242631_000.eam.alloy.yaml
@@ -2,29 +2,29 @@ species: ["Fe", "W"]
 atom_style: "atomic"
 pair_style: "eam/alloy"
 units: "metal"
-publication_year: 2018
-developer: ["Ellad Tadmor"]
-title: "EAM potential (LAMMPS cubic hermite tabulation) for the Fe-W system developed by Bonny et al. (2013) v000"
 extra_tags:
-        content_origin: "NIST IPRP (https://www.ctcms.nist.gov/potentials/Fe.html#Fe-W)"
-        content_other_locations: Null
-        data_method: "unknown"
-        description: "EAM potential for the Fe-W system developed by Bonny et al. (2013)."
-        disclaimer: "According to the developer Giovanni Bonny (as reported by the NIST IPRP), this potential was not stiffened and cannot be used in its present form for collision cascades."
-        properties: Null
-        source_citations: [
-                {
-                        "abstract": "Reduced activation steels are considered as structural materials for future fusion reactors. Besides iron and the main alloying element chromium, these steels contain other minor alloying elements, typically tungsten, vanadium and tantalum. In this work we study the impact of chromium and tungsten, being major alloying elements of ferritic Fe–Cr–W-based steels, on the stability and mobility of vacancy defects, typically formed under irradiation in collision cascades. For this purpose, we perform ab initio calculations, develop a many-body interatomic potential (EAM formalism) for large-scale calculations, validate the potential and apply it using an atomistic kinetic Monte Carlo method to characterize the lifetime and diffusivity of vacancy clusters. To distinguish the role of Cr and W we perform atomistic kinetic Monte Carlo simulations in Fe–Cr, Fe–W and Fe–Cr–W alloys. Within the limitation of transferability of the potentials it is found that both Cr and W enhance the diffusivity of vacancy clusters, while only W strongly reduces their lifetime. The cluster lifetime reduction increases with W concentration and saturates at about 1–2 at.%. The obtained results imply that W acts as an efficient ‘breaker’ of small migrating vacancy clusters and therefore the short-term annealing process of cascade debris is modified by the presence of W, even in small concentrations.",
-                        "author": "Bonny, G and Castin, N and Bullens, J and Bakaev, A and Klaver, T C P and Terentyev, D",
-                        "doi": "10.1088/0953-8984/25/31/315401",
-                        "journal": "Journal of Physics: Condensed Matter",
-                        "number": "31",
-                        "pages": "315401",
-                        "recordkey": "MO_737567242631_000a",
-                        "recordprimary": "recordprimary",
-                        "recordtype": "article",
-                        "title": "On the mobility of vacancy clusters in reduced activation steels: an atomistic study in the {Fe}-{Cr}-{W} model alloy",
-                        "volume": "25",
-                        "year": "2013"
-                }
-        ]
+    publication_year: 2018
+    developer: ["Ellad Tadmor"]
+    title: "EAM potential (LAMMPS cubic hermite tabulation) for the Fe-W system developed by Bonny et al. (2013) v000"
+    content_origin: "NIST IPRP (https://www.ctcms.nist.gov/potentials/Fe.html#Fe-W)"
+    content_other_locations: Null
+    data_method: "unknown"
+    description: "EAM potential for the Fe-W system developed by Bonny et al. (2013)."
+    disclaimer: "According to the developer Giovanni Bonny (as reported by the NIST IPRP), this potential was not stiffened and cannot be used in its present form for collision cascades."
+    properties: Null
+    source_citations: [
+        {
+            "abstract": "Reduced activation steels are considered as structural materials for future fusion reactors. Besides iron and the main alloying element chromium, these steels contain other minor alloying elements, typically tungsten, vanadium and tantalum. In this work we study the impact of chromium and tungsten, being major alloying elements of ferritic Fe–Cr–W-based steels, on the stability and mobility of vacancy defects, typically formed under irradiation in collision cascades. For this purpose, we perform ab initio calculations, develop a many-body interatomic potential (EAM formalism) for large-scale calculations, validate the potential and apply it using an atomistic kinetic Monte Carlo method to characterize the lifetime and diffusivity of vacancy clusters. To distinguish the role of Cr and W we perform atomistic kinetic Monte Carlo simulations in Fe–Cr, Fe–W and Fe–Cr–W alloys. Within the limitation of transferability of the potentials it is found that both Cr and W enhance the diffusivity of vacancy clusters, while only W strongly reduces their lifetime. The cluster lifetime reduction increases with W concentration and saturates at about 1–2 at.%. The obtained results imply that W acts as an efficient ‘breaker’ of small migrating vacancy clusters and therefore the short-term annealing process of cascade debris is modified by the presence of W, even in small concentrations.",
+            "author": "Bonny, G and Castin, N and Bullens, J and Bakaev, A and Klaver, T C P and Terentyev, D",
+            "doi": "10.1088/0953-8984/25/31/315401",
+            "journal": "Journal of Physics: Condensed Matter",
+            "number": "31",
+            "pages": "315401",
+            "recordkey": "MO_737567242631_000a",
+            "recordprimary": "recordprimary",
+            "recordtype": "article",
+            "title": "On the mobility of vacancy clusters in reduced activation steels: an atomistic study in the {Fe}-{Cr}-{W} model alloy",
+            "volume": "25",
+            "year": "2013"
+        }
+    ]

--- a/tests/input_files/parameters/FeW_MO_737567242631_000.eam.alloy.yaml
+++ b/tests/input_files/parameters/FeW_MO_737567242631_000.eam.alloy.yaml
@@ -2,15 +2,16 @@ species: ["Fe", "W"]
 atom_style: "atomic"
 pair_style: "eam/alloy"
 units: "metal"
+publication_year: 2018
+developer: ["Ellad Tadmor"]
+title: "EAM potential (LAMMPS cubic hermite tabulation) for the Fe-W system developed by Bonny et al. (2013) v000"
 extra_tags:
         content_origin: "NIST IPRP (https://www.ctcms.nist.gov/potentials/Fe.html#Fe-W)"
         content_other_locations: Null
         data_method: "unknown"
         description: "EAM potential for the Fe-W system developed by Bonny et al. (2013)."
-        developer: ["Ellad Tadmor"]
         disclaimer: "According to the developer Giovanni Bonny (as reported by the NIST IPRP), this potential was not stiffened and cannot be used in its present form for collision cascades."
         properties: Null
-        publication_year: 2018
         source_citations: [
                 {
                         "abstract": "Reduced activation steels are considered as structural materials for future fusion reactors. Besides iron and the main alloying element chromium, these steels contain other minor alloying elements, typically tungsten, vanadium and tantalum. In this work we study the impact of chromium and tungsten, being major alloying elements of ferritic Fe–Cr–W-based steels, on the stability and mobility of vacancy defects, typically formed under irradiation in collision cascades. For this purpose, we perform ab initio calculations, develop a many-body interatomic potential (EAM formalism) for large-scale calculations, validate the potential and apply it using an atomistic kinetic Monte Carlo method to characterize the lifetime and diffusivity of vacancy clusters. To distinguish the role of Cr and W we perform atomistic kinetic Monte Carlo simulations in Fe–Cr, Fe–W and Fe–Cr–W alloys. Within the limitation of transferability of the potentials it is found that both Cr and W enhance the diffusivity of vacancy clusters, while only W strongly reduces their lifetime. The cluster lifetime reduction increases with W concentration and saturates at about 1–2 at.%. The obtained results imply that W acts as an efficient ‘breaker’ of small migrating vacancy clusters and therefore the short-term annealing process of cascade debris is modified by the presence of W, even in small concentrations.",
@@ -27,4 +28,3 @@ extra_tags:
                         "year": "2013"
                 }
         ]
-        title: "EAM potential (LAMMPS cubic hermite tabulation) for the Fe-W system developed by Bonny et al. (2013) v000"

--- a/tests/input_files/parameters/Fe_MO_137964310702_004.tersoff.yaml
+++ b/tests/input_files/parameters/Fe_MO_137964310702_004.tersoff.yaml
@@ -2,15 +2,16 @@ species: ["Fe"]
 atom_style: "atomic"
 pair_style: "tersoff"
 units: "metal"
+publication_year: 2021
+developer: ["Michael Müller", "Paul Erhart", "Karsten Albe"]
+title: "Tersoff-style three-body potential for bcc and fcc Fe developed by Müller, Erhart, and Albe (2007) v004"
 extra_tags:
         content_origin: Null
         content_other_locations: Null
         data_method: "unknown"
         description: "Tersoff-style three-body potential for bcc and fcc iron by Müller, Erhart, and Albe." 
-        developer: ["Michael Müller", "Paul Erhart", "Karsten Albe"]
         disclaimer: Null 
         properties: Null
-        publication_year: 2021
         source_citations: [
                 {
                         "author": "Michael M{\\\"u}ller and Paul Erhart and Karsten Albe",
@@ -26,5 +27,4 @@ extra_tags:
                         "year": "2007",
                 }
         ]
-        title: "Tersoff-style three-body potential for bcc and fcc Fe developed by Müller, Erhart, and Albe (2007) v004"
 

--- a/tests/input_files/parameters/Fe_MO_137964310702_004.tersoff.yaml
+++ b/tests/input_files/parameters/Fe_MO_137964310702_004.tersoff.yaml
@@ -2,29 +2,29 @@ species: ["Fe"]
 atom_style: "atomic"
 pair_style: "tersoff"
 units: "metal"
-publication_year: 2021
-developer: ["Michael Müller", "Paul Erhart", "Karsten Albe"]
-title: "Tersoff-style three-body potential for bcc and fcc Fe developed by Müller, Erhart, and Albe (2007) v004"
 extra_tags:
-        content_origin: Null
-        content_other_locations: Null
-        data_method: "unknown"
-        description: "Tersoff-style three-body potential for bcc and fcc iron by Müller, Erhart, and Albe." 
-        disclaimer: Null 
-        properties: Null
-        source_citations: [
-                {
-                        "author": "Michael M{\\\"u}ller and Paul Erhart and Karsten Albe",
-                        "doi": "10.1088/0953-8984/19/32/326220",
-                        "journal": "Journal of Physics: Condensed Matter",
-                        "number": "32",
-                        "pages": "326220",
-                        "recordkey": "MO_137964310702_004a",
-                        "recordprimary": "recordprimary",
-                        "recordtype": "article",
-                        "title": "Analytic bond-order potential for bcc and fcc iron---comparison with established embedded-atom method potentials",
-                        "volume": "19",
-                        "year": "2007",
-                }
-        ]
+    publication_year: 2021
+    developer: ["Michael Müller", "Paul Erhart", "Karsten Albe"]
+    title: "Tersoff-style three-body potential for bcc and fcc Fe developed by Müller, Erhart, and Albe (2007) v004"
+    content_origin: Null
+    content_other_locations: Null
+    data_method: "unknown"
+    description: "Tersoff-style three-body potential for bcc and fcc iron by Müller, Erhart, and Albe." 
+    disclaimer: Null 
+    properties: Null
+    source_citations: [
+        {
+            "author": "Michael M{\\\"u}ller and Paul Erhart and Karsten Albe",
+            "doi": "10.1088/0953-8984/19/32/326220",
+            "journal": "Journal of Physics: Condensed Matter",
+            "number": "32",
+            "pages": "326220",
+            "recordkey": "MO_137964310702_004a",
+            "recordprimary": "recordprimary",
+            "recordtype": "article",
+            "title": "Analytic bond-order potential for bcc and fcc iron---comparison with established embedded-atom method potentials",
+            "volume": "19",
+            "year": "2007",
+        }
+    ]
 

--- a/tests/input_files/parameters/Fe_MO_331285495617_004.morse.yaml
+++ b/tests/input_files/parameters/Fe_MO_331285495617_004.morse.yaml
@@ -2,31 +2,31 @@ species: ["Fe"]
 atom_style: "atomic"
 pair_style: "morse"
 units: "metal"
-publication_year: 2020
-developer: ["Ryan S. Elliott"]
-title: "Morse potential (shifted) for Fe by Girifalco and Weizer (1959) using a low-accuracy cutoff distance v004" 
 extra_tags:
-        content_origin: Null 
-        content_other_locations: Null
-        data_method: "unknown"
-        description: "This is a Fe Morse Model Parameterization by Girifalco and Weizer (1959) using a low-accuracy cutoff distance.  The Morse parameters were calculated using experimental values for the energy of vaporization, the lattice constant, and the compressibility. The equation of state and the elastic constants which were computed using the Morse parameters, agreed with experiment for both face-centered and body-centered cubic metals. All stability conditions were also satisfied for both the face-centered and the body-centered metals. This shows that the Morse function can be applied validly to problems involving any type of deformation of the cubic metals."
-        disclaimer: "According to the developer Giovanni Bonny (as reported by the NIST IPRP), this potential was not stiffened and cannot be used in its present form for collision cascades."
-        properties: Null
-        source_citations: [
-                {
-                        "author": "Girifalco, L. A. and Weizer, V. G.",
-                        "doi": "10.1103/PhysRev.114.687",
-                        "issue": "3",
-                        "journal": "Physical Review",
-                        "month": "May",
-                        "numpages": "0",
-                        "pages": "687--690",
-                        "publisher": "American Physical Society",
-                        "recordkey": "MO_331285495617_004a",
-                        "recordprimary": "recordprimary",
-                        "recordtype": "article",
-                        "title": "Application of the {M}orse Potential Function to Cubic Metals",
-                        "volume": "114",
-                        "year": "1959",
-                }
-        ]
+    publication_year: 2020
+    developer: ["Ryan S. Elliott"]
+    title: "Morse potential (shifted) for Fe by Girifalco and Weizer (1959) using a low-accuracy cutoff distance v004" 
+    content_origin: Null 
+    content_other_locations: Null
+    data_method: "unknown"
+    description: "This is a Fe Morse Model Parameterization by Girifalco and Weizer (1959) using a low-accuracy cutoff distance.  The Morse parameters were calculated using experimental values for the energy of vaporization, the lattice constant, and the compressibility. The equation of state and the elastic constants which were computed using the Morse parameters, agreed with experiment for both face-centered and body-centered cubic metals. All stability conditions were also satisfied for both the face-centered and the body-centered metals. This shows that the Morse function can be applied validly to problems involving any type of deformation of the cubic metals."
+    disclaimer: "According to the developer Giovanni Bonny (as reported by the NIST IPRP), this potential was not stiffened and cannot be used in its present form for collision cascades."
+    properties: Null
+    source_citations: [
+        {
+            "author": "Girifalco, L. A. and Weizer, V. G.",
+            "doi": "10.1103/PhysRev.114.687",
+            "issue": "3",
+            "journal": "Physical Review",
+            "month": "May",
+            "numpages": "0",
+            "pages": "687--690",
+            "publisher": "American Physical Society",
+            "recordkey": "MO_331285495617_004a",
+            "recordprimary": "recordprimary",
+            "recordtype": "article",
+            "title": "Application of the {M}orse Potential Function to Cubic Metals",
+            "volume": "114",
+            "year": "1959",
+        }
+    ]

--- a/tests/input_files/parameters/Fe_MO_331285495617_004.morse.yaml
+++ b/tests/input_files/parameters/Fe_MO_331285495617_004.morse.yaml
@@ -2,15 +2,16 @@ species: ["Fe"]
 atom_style: "atomic"
 pair_style: "morse"
 units: "metal"
+publication_year: 2020
+developer: ["Ryan S. Elliott"]
+title: "Morse potential (shifted) for Fe by Girifalco and Weizer (1959) using a low-accuracy cutoff distance v004" 
 extra_tags:
         content_origin: Null 
         content_other_locations: Null
         data_method: "unknown"
         description: "This is a Fe Morse Model Parameterization by Girifalco and Weizer (1959) using a low-accuracy cutoff distance.  The Morse parameters were calculated using experimental values for the energy of vaporization, the lattice constant, and the compressibility. The equation of state and the elastic constants which were computed using the Morse parameters, agreed with experiment for both face-centered and body-centered cubic metals. All stability conditions were also satisfied for both the face-centered and the body-centered metals. This shows that the Morse function can be applied validly to problems involving any type of deformation of the cubic metals."
-        developer: ["Ryan S. Elliott"]
         disclaimer: "According to the developer Giovanni Bonny (as reported by the NIST IPRP), this potential was not stiffened and cannot be used in its present form for collision cascades."
         properties: Null
-        publication_year: 2020
         source_citations: [
                 {
                         "author": "Girifalco, L. A. and Weizer, V. G.",
@@ -29,4 +30,3 @@ extra_tags:
                         "year": "1959",
                 }
         ]
-        title: "Morse potential (shifted) for Fe by Girifalco and Weizer (1959) using a low-accuracy cutoff distance v004" 

--- a/tests/input_files/parameters/Fe_MO_492310898779_001.meam.yaml
+++ b/tests/input_files/parameters/Fe_MO_492310898779_001.meam.yaml
@@ -2,30 +2,30 @@ species: ["Fe"]
 atom_style: "atomic"
 pair_style: "meam"
 units: "metal"
-publication_year: 2021
-developer: ["Ebrahim Asadi", "Mohsen Asle Zaeem", "Sasan Nouranian", "Michael I. Baskes"]
-title: "MEAM potential for Fe developed by Asadi et al. (2015) v001"
 extra_tags:
-        content_origin: "NIST IPRP (https://www.ctcms.nist.gov/potentials/Fe.html)"
-        content_other_locations: Null
-        data_method: "unknown"
-        description: "In this paper, molecular dynamics (MD) simulations based on the modified-embedded atom method (MEAM) and a phase-field crystal (PFC) model are utilized to quantitatively investigate the solid-liquid properties of Fe. A set of second nearest-neighbor MEAM parameters for high-temperature applications are developed for Fe, and the solid-liquid coexisting approach is utilized in MD simulations to accurately calculate the melting point, expansion in melting, latent heat, and solid-liquid interface free energy, and surface anisotropy. The required input properties to determine the PFC model parameters, such as liquid structure factor and fluctuations of atoms in the solid, are also calculated from MD simulations. The PFC parameters are calculated utilizing an iterative procedure from the inputs of MD simulations. The solid-liquid interface free energy and surface anisotropy are calculated using the PFC simulations. Very good agreement is observed between the results of our calculations from MEAM-MD and PFC simulations and the available modeling and experimental results in the literature. As an application of the developed model, the grain boundary free energy of Fe is calculated using the PFC model and the results are compared against experiments." 
-        disclaimer: Null 
-        properties: Null
-        source_citations: [
-                {
-                        "author": "Asadi, E. and Zaeem, M. A. and Nouranian, S. and Baskes, M. I.",
-                        "doi": "10.1103/PhysRevB.91.024105",
-                        "journal": "Phys. Rev. B",
-                        "month": "Jan",
-                        "note": "",
-                        "number": "",
-                        "pages": "024105",
-                        "recordkey": "MO_492310898779_001a",
-                        "recordprimary": "recordprimary",
-                        "recordtype": "article",
-                        "title": "Quantitative modeling of the equilibration of two-phase solid-liquid {F}e by atomistic simulations on diffusive time scales",
-                        "volume": "91",
-                        "year": "2015",
-                }
-        ]
+    publication_year: 2021
+    developer: ["Ebrahim Asadi", "Mohsen Asle Zaeem", "Sasan Nouranian", "Michael I. Baskes"]
+    title: "MEAM potential for Fe developed by Asadi et al. (2015) v001"
+    content_origin: "NIST IPRP (https://www.ctcms.nist.gov/potentials/Fe.html)"
+    content_other_locations: Null
+    data_method: "unknown"
+    description: "In this paper, molecular dynamics (MD) simulations based on the modified-embedded atom method (MEAM) and a phase-field crystal (PFC) model are utilized to quantitatively investigate the solid-liquid properties of Fe. A set of second nearest-neighbor MEAM parameters for high-temperature applications are developed for Fe, and the solid-liquid coexisting approach is utilized in MD simulations to accurately calculate the melting point, expansion in melting, latent heat, and solid-liquid interface free energy, and surface anisotropy. The required input properties to determine the PFC model parameters, such as liquid structure factor and fluctuations of atoms in the solid, are also calculated from MD simulations. The PFC parameters are calculated utilizing an iterative procedure from the inputs of MD simulations. The solid-liquid interface free energy and surface anisotropy are calculated using the PFC simulations. Very good agreement is observed between the results of our calculations from MEAM-MD and PFC simulations and the available modeling and experimental results in the literature. As an application of the developed model, the grain boundary free energy of Fe is calculated using the PFC model and the results are compared against experiments." 
+    disclaimer: Null 
+    properties: Null
+    source_citations: [
+        {
+            "author": "Asadi, E. and Zaeem, M. A. and Nouranian, S. and Baskes, M. I.",
+            "doi": "10.1103/PhysRevB.91.024105",
+            "journal": "Phys. Rev. B",
+            "month": "Jan",
+            "note": "",
+            "number": "",
+            "pages": "024105",
+            "recordkey": "MO_492310898779_001a",
+            "recordprimary": "recordprimary",
+            "recordtype": "article",
+            "title": "Quantitative modeling of the equilibration of two-phase solid-liquid {F}e by atomistic simulations on diffusive time scales",
+            "volume": "91",
+            "year": "2015",
+        }
+    ]

--- a/tests/input_files/parameters/Fe_MO_492310898779_001.meam.yaml
+++ b/tests/input_files/parameters/Fe_MO_492310898779_001.meam.yaml
@@ -2,15 +2,16 @@ species: ["Fe"]
 atom_style: "atomic"
 pair_style: "meam"
 units: "metal"
+publication_year: 2021
+developer: ["Ebrahim Asadi", "Mohsen Asle Zaeem", "Sasan Nouranian", "Michael I. Baskes"]
+title: "MEAM potential for Fe developed by Asadi et al. (2015) v001"
 extra_tags:
         content_origin: "NIST IPRP (https://www.ctcms.nist.gov/potentials/Fe.html)"
         content_other_locations: Null
         data_method: "unknown"
         description: "In this paper, molecular dynamics (MD) simulations based on the modified-embedded atom method (MEAM) and a phase-field crystal (PFC) model are utilized to quantitatively investigate the solid-liquid properties of Fe. A set of second nearest-neighbor MEAM parameters for high-temperature applications are developed for Fe, and the solid-liquid coexisting approach is utilized in MD simulations to accurately calculate the melting point, expansion in melting, latent heat, and solid-liquid interface free energy, and surface anisotropy. The required input properties to determine the PFC model parameters, such as liquid structure factor and fluctuations of atoms in the solid, are also calculated from MD simulations. The PFC parameters are calculated utilizing an iterative procedure from the inputs of MD simulations. The solid-liquid interface free energy and surface anisotropy are calculated using the PFC simulations. Very good agreement is observed between the results of our calculations from MEAM-MD and PFC simulations and the available modeling and experimental results in the literature. As an application of the developed model, the grain boundary free energy of Fe is calculated using the PFC model and the results are compared against experiments." 
-        developer: ["Ebrahim Asadi", "Mohsen Asle Zaeem", "Sasan Nouranian", "Michael I. Baskes"]
         disclaimer: Null 
         properties: Null
-        publication_year: 2021
         source_citations: [
                 {
                         "author": "Asadi, E. and Zaeem, M. A. and Nouranian, S. and Baskes, M. I.",
@@ -28,4 +29,3 @@ extra_tags:
                         "year": "2015",
                 }
         ]
-        title: "MEAM potential for Fe developed by Asadi et al. (2015) v001"


### PR DESCRIPTION
Adding the `publication_year`, `developer` and `title` to the list of required parameters when one is creating the `LammpsPotentialData` node.

The idea behind this is to make sure that the potentials are more easily queriable, and the developer name, title and year are amongst the most common of the tags that one would use to try to get the potential from the database.

Fixes #72 