### PR TITLE
`LammpsBaseCalculation`: Add the `files` and `filenames` inputs

### DIFF
--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -355,3 +355,81 @@ def test_lammps_base_settings(generate_calc_job, aiida_local_code_factory):
 
     _, calc_info = generate_calc_job("lammps.base", inputs)
     assert calc_info.codes_info[0].cmdline_params[-2:] == ["--option", "value"]
+
+
+def test_lammps_base_files_invalid(generate_calc_job, aiida_local_code_factory):
+    """Test the ``files`` input valdiation.
+
+    The list of filenames that will be used to write to the working directory needs to be unique.
+    """
+    # Create two ``SinglefileData`` nodes without specifying an explicit filename. This will cause the default to be
+    # used, and so both will have the same filename, which should trigger the validation error.
+    inputs = {
+        "code": aiida_local_code_factory("lammps.base", "bash"),
+        "script": orm.SinglefileData(io.StringIO("")),
+        "files": {
+            "file_a": orm.SinglefileData(io.StringIO("content")),
+            "file_b": orm.SinglefileData(io.StringIO("content")),
+        },
+        "metadata": {"options": {"resources": {"num_machines": 1}}},
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"The list of filenames of the ``files`` input is not unique:.*",
+    ):
+        generate_calc_job("lammps.base", inputs)
+
+
+def test_lammps_base_filenames_invalid(generate_calc_job, aiida_local_code_factory):
+    """Test the ``filenames`` input valdiation.
+
+    The list of filenames that will be used to write to the working directory needs to be unique.
+    """
+    # Create two ``SinglefileData`` nodes with unique filenames but override them using the ``filenames`` input to use
+    # the same filename, and so both will have the same filename, which should trigger the validation error.
+    inputs = {
+        "code": aiida_local_code_factory("lammps.base", "bash"),
+        "script": orm.SinglefileData(io.StringIO("")),
+        "files": {
+            "file_a": orm.SinglefileData(io.StringIO("content"), filename="file_a.txt"),
+            "file_b": orm.SinglefileData(io.StringIO("content"), filename="file_b.txt"),
+        },
+        "filenames": {
+            "file_a": "file.txt",
+            "file_b": "file.txt",
+        },
+        "metadata": {"options": {"resources": {"num_machines": 1}}},
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"The list of filenames of the ``files`` input is not unique:.*",
+    ):
+        generate_calc_job("lammps.base", inputs)
+
+
+def test_lammps_base_files(generate_calc_job, aiida_local_code_factory):
+    """Test the ``files`` input."""
+    inputs = {
+        "code": aiida_local_code_factory("lammps.base", "bash"),
+        "script": orm.SinglefileData(io.StringIO("")),
+        "files": {
+            "file_a": orm.SinglefileData(
+                io.StringIO("content a"), filename="file_a.txt"
+            ),
+            "file_b": orm.SinglefileData(
+                io.StringIO("content b"), filename="file_b.txt"
+            ),
+        },
+        "filenames": {"file_b": "custom_filename.txt"},
+        "metadata": {"options": {"resources": {"num_machines": 1}}},
+    }
+
+    tmp_path, calc_info = generate_calc_job("lammps.base", inputs)
+    assert sorted(calc_info.provenance_exclude_list) == [
+        "custom_filename.txt",
+        "file_a.txt",
+    ]
+    assert (tmp_path / "file_a.txt").read_text() == "content a"
+    assert (tmp_path / "custom_filename.txt").read_text() == "content b"


### PR DESCRIPTION
The `files` input namespace allows a user to pass in additional files to be written to the working directory. By default, the filename to write the content of each `SinglefileData` node to, defaults to the filename attribute of the node itself. A validator ensures that the list of filenames is unique, because otherwise some files would end up overwriting others.

If this is the case, the optional `filenames` input can be specified to override the default filename in order to avoid these clashes.