### PR TITLE
LammpsPotential: adapt for using Nequip potentials

### DIFF
--- a/aiida_lammps/calculations/base.py
+++ b/aiida_lammps/calculations/base.py
@@ -41,7 +41,7 @@ class LammpsBaseCalculation(CalcJob):
         "parser_name": "lammps.base",
     }
 
-    _POTENTIAL_FILENAME = "potential.dat"
+    _POTENTIAL_FILENAME = "potential.pth"
 
     # In restarts, will not copy but use symlinks
     _default_symlink_usage = True
@@ -365,8 +365,12 @@ class LammpsBaseCalculation(CalcJob):
             handle.write(structure_filecontent)
 
         # Write the potential to the remote folder
-        with folder.open(self._POTENTIAL_FILENAME, "w") as handle:
-            handle.write(self.inputs.potential.get_content())
+        # with folder.open(self._POTENTIAL_FILENAME, "w") as handle:
+        #     handle.write(self.inputs.potential.get_content())
+        
+        with folder.open(self._POTENTIAL_FILENAME, 'wb') as handle1:
+            with self.inputs.potential.open(mode='rb') as handle2:    
+                handle1.write(handle2.read())
 
         # Write the input file content. This function will also check the
         # sanity of the passed parameters when comparing it to a schema
@@ -374,6 +378,7 @@ class LammpsBaseCalculation(CalcJob):
             potential=self.inputs.potential,
             structure=self.inputs.structure,
             parameters=_parameters,
+            potential_filename=self._POTENTIAL_FILENAME,
             restart_filename=_restart_filename,
             trajectory_filename=_trajectory_filename,
             variables_filename=_variables_filename,

--- a/aiida_lammps/data/lammps_potentials.json
+++ b/aiida_lammps/data/lammps_potentials.json
@@ -28,6 +28,8 @@
         "wavepacket"
     ],
     "pair_style": {
+        "allegro":{"units": "metal", "atom_style": "atomic", "read_from_file": true},
+        "nequip":{"units": "metal", "atom_style": "atomic", "read_from_file": true},
         "adp":{"units": "unknown", "atom_style": "atomic", "read_from_file": true},
         "agni":{"units": "unknown", "atom_style": "atomic", "read_from_file": true},
         "airebo":{"units": "unknown", "atom_style": "atomic", "read_from_file": true},


### PR DESCRIPTION
The current implementation cannot exploit other potentials, such as neural network potentials, in this case, coming from Nequip architecture. The implementation now is extended to be able to use this ML family of potentials.