### PR TITLE
116 dependabot tests failing for python38

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,7 +83,7 @@ jobs:
           tox -e ${{ matrix.python-version }}-aiida_lammps -- tests/ --cov=./aiida_lammps --cov-append --cov-report=xml --cov-report=term-missing
 
       - name: Upload to Codecov
-        if: matrix.python-version == 3.9
+        if: matrix.python-version == 3.10
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,8 +39,6 @@ jobs:
             lammps-version: "2023.08.02"
           - python-version: "3.11"
             lammps-version: "2022.06.23"
-          - python-version: "3.12"
-            lammps-version: "2024.02.07"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3.3.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.9"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,11 +32,9 @@ jobs:
           - python-version: "3.9"
             lammps-version: "2020.12.24"
           - python-version: "3.9"
-            lammps-version: "2023.08.02"
-          - python-version: "3.10"
             lammps-version: "2022.06.23"
           - python-version: "3.10"
-            lammps-version: "2023.08.02"
+            lammps-version: "2022.06.23"
           - python-version: "3.11"
             lammps-version: "2022.06.23"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,13 +31,12 @@ jobs:
         include:
           - python-version: "3.9"
             lammps-version: "2020.12.24"
-            backend: sqlalchemy
-          - python-version: "3.9"
-            lammps-version: "2020.12.24"
-            backend: django
           - python-version: "3.10"
             lammps-version: "2021.09.29"
-            backend: django
+          - python-version: "3.11"
+            lammps-version: "2021.09.29"
+          - python-version: "3.12"
+            lammps-version: "2021.09.29"
 
     runs-on: ubuntu-latest
 
@@ -45,7 +44,7 @@ jobs:
       postgres:
         image: postgres:12
         env:
-          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_DB: test
           POSTGRES_PASSWORD: ""
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,12 +31,16 @@ jobs:
         include:
           - python-version: "3.9"
             lammps-version: "2020.12.24"
+          - python-version: "3.9"
+            lammps-version: "2023.08.02"
           - python-version: "3.10"
-            lammps-version: "2021.09.29"
+            lammps-version: "2022.06.23"
+          - python-version: "3.10"
+            lammps-version: "2023.08.02"
           - python-version: "3.11"
-            lammps-version: "2021.09.29"
+            lammps-version: "2022.06.23"
           - python-version: "3.12"
-            lammps-version: "2021.09.29"
+            lammps-version: "2024.02.07"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Make sure virtualevn>20 is installed, which will yield newer pip and possibility to pin pip version.
         run: pip install "virtualenv>20"
       - name: Install Tox
@@ -29,10 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.8"
-            lammps-version: "2020.12.24"
-            backend: django
-          - python-version: "3.8"
+          - python-version: "3.9"
             lammps-version: "2020.12.24"
             backend: sqlalchemy
           - python-version: "3.9"
@@ -86,7 +83,7 @@ jobs:
           tox -e ${{ matrix.python-version }}-aiida_lammps -- tests/ --cov=./aiida_lammps --cov-append --cov-report=xml --cov-report=term-missing
 
       - name: Upload to Codecov
-        if: matrix.python-version == 3.8
+        if: matrix.python-version == 3.9
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -105,7 +102,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: install flit
         run: |
           pip install flit~=3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload to Codecov
         if: matrix.python-version == 3.10
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: pytests-lammps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,9 @@ jobs:
           - python-version: "3.9"
             lammps-version: "2020.12.24"
           - python-version: "3.9"
-            lammps-version: "2023.08.02"
-          - python-version: "3.10"
             lammps-version: "2022.06.23"
           - python-version: "3.10"
-            lammps-version: "2023.08.02"
+            lammps-version: "2022.06.23"
           - python-version: "3.11"
             lammps-version: "2022.06.23"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Make sure virtualevn>20 is installed, which will yield newer pip and possibility to pin pip version.
         run: pip install "virtualenv>20"
       - name: Install Tox
@@ -28,10 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.8"
+          - python-version: "3.9"
             lammps-version: "2020.03.03"
-          - python-version: "3.8"
-            lammps-version: "2020.12.24"
           - python-version: "3.9"
             lammps-version: "2020.12.24"
           - python-version: "3.9"
@@ -87,7 +85,7 @@ jobs:
           tox -e ${{ matrix.python-version }}-aiida_lammps -- tests/ --cov=./aiida_lammps --cov-append --cov-report=xml --cov-report=term-missing
 
       - name: Upload to Codecov
-        if: matrix.python-version == 3.8
+        if: matrix.python-version == 3.9
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
             lammps-version: "2023.08.02"
           - python-version: "3.11"
             lammps-version: "2022.06.23"
-          - python-version: "3.12"
-            lammps-version: "2024.02.07"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,16 @@ jobs:
         include:
           - python-version: "3.9"
             lammps-version: "2020.12.24"
+          - python-version: "3.9"
+            lammps-version: "2023.08.02"
           - python-version: "3.10"
-            lammps-version: "2021.09.29"
+            lammps-version: "2022.06.23"
+          - python-version: "3.10"
+            lammps-version: "2023.08.02"
           - python-version: "3.11"
-            lammps-version: "2021.09.29"
+            lammps-version: "2022.06.23"
           - python-version: "3.12"
-            lammps-version: "2021.09.29"
+            lammps-version: "2024.02.07"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload to Codecov
         if: matrix.python-version == 3.10
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: pytests-lammps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           tox -e ${{ matrix.python-version }}-aiida_lammps -- tests/ --cov=./aiida_lammps --cov-append --cov-report=xml --cov-report=term-missing
 
       - name: Upload to Codecov
-        if: matrix.python-version == 3.9
+        if: matrix.python-version == 3.10
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       matrix:
         include:
           - python-version: "3.9"
-            lammps-version: "2020.03.03"
-          - python-version: "3.9"
             lammps-version: "2020.12.24"
-          - python-version: "3.9"
-            lammps-version: "2020.03.03"
           - python-version: "3.10"
+            lammps-version: "2021.09.29"
+          - python-version: "3.11"
+            lammps-version: "2021.09.29"
+          - python-version: "3.12"
             lammps-version: "2021.09.29"
 
     runs-on: ubuntu-latest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,11 +4,11 @@ It is recommended to use tox to run the build (see tox.ini):
 `tox -e docs-clean` and `tox -e docs-update`,
 or directly: `sphinx-build -n -W --keep-going docs/source docs/_build`
 """
+
 import pathlib
 import time
 
-from aiida.manage.configuration import load_documentation_profile
-
+from aiida.manage.configuration import Profile, load_profile
 from aiida_lammps import __version__
 
 # -- AiiDA-related setup --------------------------------------------------
@@ -16,7 +16,7 @@ from aiida_lammps import __version__
 # Load the dummy profile even if we are running locally, this way the
 # documentation will succeed even if the current
 # default profile of the AiiDA installation does not use a Django backend.
-load_documentation_profile()
+load_profile(Profile("docs", {"process_control": {}, "storage": {}}))
 
 project = "AiiDA LAMMPS"
 copyright = f"2021-{time.localtime().tm_year}, AiiDA Team. All rights reserved"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ import pathlib
 import time
 
 from aiida.manage.configuration import Profile, load_profile
+
 from aiida_lammps import __version__
 
 # -- AiiDA-related setup --------------------------------------------------

--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -32,7 +32,7 @@ The test suite can be run in an isolated, virtual environment using `tox` (see `
 
 ```console
 pip install tox
-tox -e 3.8-aiida_lammps
+tox -e 3.9-aiida_lammps
 ```
 
 or directly:
@@ -57,7 +57,7 @@ conda install lammps==2019.06.05
 You can specify a different executable name for LAMMPS with:
 
 ```console
-tox -e 3.8-aiida_lammps -- --lammps-exec lmp_exec
+tox -e 3.9-aiida_lammps -- --lammps-exec lmp_exec
 ```
 
 To output the results of calcjob executions to a specific directory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,30 +5,33 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "aiida-lammps"
 dynamic = ["version", "description"]
-authors = [{name = "Chris Sewell", email = "chrisj_sewell@hotmail.com"}, {name = "Jonathan Chico", email = "jonathan.chico@sandvik.com"}]
+authors = [
+    { name = "Chris Sewell", email = "chrisj_sewell@hotmail.com" },
+    { name = "Jonathan Chico", email = "jonathan.chico@sandvik.com" },
+]
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Physics",
-    "Framework :: AiiDA"
+    "Framework :: AiiDA",
 ]
 keywords = ["aiida", "workflows", "lammps"]
 requires-python = ">=3.8"
 dependencies = [
     "aiida-core[atomic_tools]>=2.0.0,<3.0.0",
     "importlib_resources",
-    "jsonschema",
+    "jsonschema~=3.2.0",
     "numpy",
     "packaging",
-    "python-dateutil"
+    "python-dateutil",
 ]
 
 [project.urls]
@@ -43,7 +46,7 @@ tests = [
     "pytest-cov",
     "coverage",
     "pytest-timeout",
-    "pytest-regressions"
+    "pytest-regressions",
 ]
 
 pre-commit = [
@@ -62,7 +65,7 @@ docs = [
     'sphinxcontrib-details-directive~=0.1.0',
     'sphinx-autoapi~=3.0',
     'myst_parser~=1.0.0',
-    "furo"
+    "furo",
 ]
 
 [project.entry-points."aiida.calculations"]
@@ -86,15 +89,12 @@ docs = [
 name = "aiida_lammps"
 
 [tool.flit.sdist]
-exclude = [
-    "docs/",
-    "tests/",
-]
+exclude = ["docs/", "tests/"]
 
 [tool.coverage.run]
 # Configuration of [coverage.py](https://coverage.readthedocs.io)
 # reporting which lines of your plugin are covered by tests
-source=["aiida_lammps"]
+source = ["aiida_lammps"]
 
 [tool.isort]
 skip = ["venv"]
@@ -112,7 +112,7 @@ profile = "black"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = pre-commit,{3.8,3.9,3.10}-aiida_lammps
+envlist = pre-commit,{3.9,3.10,3.11}-aiida_lammps
 requires = virtualenv >= 20
 isolated_build = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,13 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Physics",
     "Framework :: AiiDA",
 ]
 keywords = ["aiida", "workflows", "lammps"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "aiida-core[atomic_tools]~=2.3",
     "importlib_resources",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ["aiida", "workflows", "lammps"]
 requires-python = ">=3.8"
 dependencies = [
-    "aiida-core[atomic_tools]>=2.0.0,<3.0.0",
+    "aiida-core[atomic_tools]~=2.3",
     "importlib_resources",
     "jsonschema~=3.2.0",
     "numpy",


### PR DESCRIPTION
Fixing an issue in which the newer versions of jsonschema were causing the tests to fail. 

Have pinned the jsonschema dependency and removed some leftover python 3.8 tests and mentions.

Fixes #116 